### PR TITLE
Fix render loop by wrapping searchManga in useCallback

### DIFF
--- a/src/helpers/useSearchMangaList.ts
+++ b/src/helpers/useSearchMangaList.ts
@@ -1,5 +1,6 @@
 import { gql, useLazyQuery } from "@apollo/client";
 import { DateTime } from "luxon";
+import { useCallback } from "react";
 import {
   ContentRating,
   defaultPagedResults,
@@ -113,21 +114,24 @@ export default function useSearchMangaList({
     },
   });
 
-  const searchManga = (options: SearchOptions) => {
-    const filteredOptions = Object.fromEntries(
-      Object.entries(options).filter(([_, v]) => {
-        return v != null && ((Array.isArray(v) && v.length > 0) || v !== "");
-      })
-    );
+  const searchManga = useCallback(
+    (options: SearchOptions) => {
+      const filteredOptions = Object.fromEntries(
+        Object.entries(options).filter(([_, v]) => {
+          return v != null && ((Array.isArray(v) && v.length > 0) || v !== "");
+        })
+      );
 
-    callback({
-      variables: {
-        limit,
-        offset,
-        ...filteredOptions,
-      },
-    });
-  };
+      callback({
+        variables: {
+          limit,
+          offset,
+          ...filteredOptions,
+        },
+      });
+    },
+    [limit, offset, callback]
+  );
 
   const { data, loading, error, fetchMore } = result;
 


### PR DESCRIPTION
### Description

Since `searchManga` was not a memoized callback, it would be recreated on each render. This caused a `useEffect` in `JumpToMangaSearchField` to run, since it there was a dependency on `searchManga`. 

### Solution

Make `searchManga` a memoized callback dependent on `limit`, `offset` and the `useLazyQuery`'s `callback`.
