### PR TITLE
Authenticate user (log in and out flows)

### DIFF
--- a/proxy/logger.js
+++ b/proxy/logger.js
@@ -1,4 +1,3 @@
-const e = require("express");
 const strftime = require("strftime");
 const { cacheKey } = require("./middleware/cache");
 const formatDatetime = strftime.localizeByIdentifier("en_CA");

--- a/proxy/logger.js
+++ b/proxy/logger.js
@@ -1,3 +1,4 @@
+const e = require("express");
 const strftime = require("strftime");
 const { cacheKey } = require("./middleware/cache");
 const formatDatetime = strftime.localizeByIdentifier("en_CA");
@@ -14,6 +15,21 @@ const print = (level, message, ...otherParams) => {
     message,
     ...otherParams
   );
+};
+
+const printObject = (identifier, object) => {
+  const sensitiveFields = ["Authorization", "password"];
+  if (process.env.DEBUG === "true") {
+    debug(`${identifier}:`, object);
+  } else {
+    const copiedObject = { ...object };
+    Object.keys(copiedObject).forEach((key) => {
+      if (sensitiveFields.includes(key)) {
+        copiedObject[key] = "[REDACTED]";
+      }
+    });
+    info(`${identifier}:`, copiedObject);
+  }
 };
 
 const info = (message, ...otherParams) => {
@@ -74,3 +90,4 @@ exports.warn = warn;
 exports.error = error;
 exports.fatal = fatal;
 exports.info = info;
+exports.printObject = printObject;

--- a/proxy/logger.js
+++ b/proxy/logger.js
@@ -48,6 +48,7 @@ const basicExpressLogger = function (req, res, next) {
     "\x1b[0m",
     req.originalUrl
   );
+  debug(`(${cacheKey(req).slice(0, 10)})`, "Headers:", req.headers);
 
   res.on("finish", () => {
     const end = new Date();

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -24,6 +24,11 @@
         "uri-js": "^4.2.2"
       }
     },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -532,6 +537,14 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
       "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "requires": {
+        "argparse": "^2.0.1"
+      }
     },
     "jsbn": {
       "version": "0.1.1",

--- a/proxy/server.js
+++ b/proxy/server.js
@@ -290,15 +290,12 @@ function proxyRequest(req, res, requestPath, proxiedHeaders) {
   log.info(
     `Proxying request ${requestCacheKey} to ${req.method} ${requestPath} with body`
   );
-  console.log(req.body);
-  log.info("headers", {
-    Authorization: req.header("Authorization")
-      ? process.env.DEBUG === "true"
-        ? req.header("Authorization")
-        : "[REDACTED]"
-      : "undefined",
+  log.printObject("Body", req.body);
+  const headers = {
+    Authorization: req.header("Authorization") || "",
     ...proxiedHeaders,
-  });
+  };
+  log.printObject("Headers", headers);
 
   const body = Object.keys(req.body).length === 0 ? undefined : req.body;
 
@@ -306,7 +303,7 @@ function proxyRequest(req, res, requestPath, proxiedHeaders) {
     {
       url: requestPath,
       method: req.method,
-      headers: req.headers,
+      headers,
       json: body,
     },
     function (error, response) {

--- a/proxy/server.js
+++ b/proxy/server.js
@@ -218,7 +218,7 @@ function proxyRequest(req, res, requestPath, proxiedHeaders) {
     ...proxiedHeaders,
   });
 
-  const body = Object.keys(req.body).length === 0 ? undefined : res.body;
+  const body = Object.keys(req.body).length === 0 ? undefined : req.body;
 
   request(
     {

--- a/proxy/server.js
+++ b/proxy/server.js
@@ -1,6 +1,7 @@
 var express = require("express"),
   request = require("request"),
   geoip = require("geoip-lite"),
+  axios = require("axios"),
   app = express();
 
 const log = require("./logger");
@@ -148,6 +149,84 @@ app.get("/version", (req, res) => {
       res.send({ version: yaml.load(response.body).info.version });
     }
   });
+});
+
+app.get("/auth/check-and-refresh", async (req, res) => {
+  const session = req.headers["x-auth-session"];
+  const refresh = req.headers["x-auth-refresh"];
+
+  if (session.length === 0 && refresh.length === 0) {
+    return res
+      .status(401)
+      .send({ error: true, message: "No session or refresh token." });
+  }
+
+  if (session.length) {
+    const bearerToken = session.trim();
+    const { data: checkAuthData } = await axios.request({
+      baseURL: "https://api.mangadex.org",
+      method: "GET",
+      url: "/auth/check",
+      headers: {
+        Authorization: bearerToken,
+      },
+    });
+
+    if (checkAuthData.result !== "ok") {
+      return res.status(400).send({
+        error: true,
+        message: "Could not check the validity of the token",
+        bearerToken,
+      });
+    }
+
+    try {
+      const { data: getUserData } = await axios.request({
+        baseURL: "https://api.mangadex.org",
+        method: "GET",
+        url: "/user/me",
+        headers: {
+          Authorization: bearerToken,
+        },
+      });
+
+      if (getUserData.result === "ok") {
+        return res.send({ ...getUserData });
+      }
+    } catch (e) {
+      console.log("could not get user info", e.response.status);
+    }
+  }
+
+  if (refresh.length) {
+    try {
+      const { data } = await axios.request({
+        baseURL: "https://api.mangadex.org",
+        method: "POST",
+        url: "/auth/refresh",
+        data: { token: refresh },
+      });
+
+      if (data.result === "ok") {
+        const newSession = data.token.session;
+
+        const { data: getUserData } = await axios.request({
+          baseURL: "https://api.mangadex.org",
+          method: "GET",
+          url: "/user/me",
+          headers: {
+            Authorization: newSession,
+          },
+        });
+
+        return res.send({ ...getUserData, ...data.token });
+      }
+    } catch (e) {
+      console.log("could not refresh token", e.response.status);
+    }
+  }
+
+  res.status(401).send({ error: true });
 });
 
 app.all("*", function (req, res, next) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,13 @@
-import { APIProvider, RootProvider } from "config/providers";
+import { APIProvider, AuthProvider, RootProvider } from "config/providers";
 import { AppRouter } from "routes";
 
 function App() {
   return (
     <RootProvider>
       <APIProvider>
-        <AppRouter />
+        <AuthProvider>
+          <AppRouter />
+        </AuthProvider>
       </APIProvider>
     </RootProvider>
   );

--- a/src/components/modals/LoginModal/LoginModal.tsx
+++ b/src/components/modals/LoginModal/LoginModal.tsx
@@ -1,10 +1,10 @@
 import {
   FormControl,
   OutlinedInput,
-  InputLabel,
   makeStyles,
   Button,
 } from "@material-ui/core";
+import useLogin from "helpers/useLogin";
 import { useMemo, useState } from "react";
 import BasicModal from "../BasicModal";
 
@@ -33,6 +33,14 @@ export default function LoginModal({ open, onClose }: Props) {
   const classes = useStyles();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+
+  const { loginUser } = useLogin();
+
+  const loginNow = () => {
+    if (validEntry) {
+      loginUser({ username, password });
+    }
+  };
 
   const validEntry = useMemo(
     () =>
@@ -74,6 +82,7 @@ export default function LoginModal({ open, onClose }: Props) {
             size="large"
             variant="contained"
             color="primary"
+            onClick={loginNow}
           >
             Sign in
           </Button>

--- a/src/components/modals/LoginModal/LoginModal.tsx
+++ b/src/components/modals/LoginModal/LoginModal.tsx
@@ -34,17 +34,19 @@ export default function LoginModal({ open, onClose }: Props) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
+  const [loggedIn, setLoggedIn] = useState(false);
 
-  const { loginUser } = useLogin();
+  const { loginUser } = useLogin({
+    onLogin: (response) => {
+      setLoggedIn(response.result === "ok");
+      setLoading(false);
+    },
+  });
 
   const loginNow = () => {
     if (validEntry && !loading) {
       setLoading(true);
-      loginUser({ username, password }).then((user) => {
-        if (user) {
-          alert("welcome, " + user.attributes.username);
-        }
-      });
+      loginUser({ username, password });
     }
   };
 
@@ -60,7 +62,7 @@ export default function LoginModal({ open, onClose }: Props) {
     <BasicModal
       title="Sign in"
       description="Enter your MangaDex account credentials below."
-      open={open}
+      open={open && !loggedIn}
       onClose={onClose}
     >
       <form noValidate autoComplete="off" className={classes.root}>

--- a/src/components/modals/LoginModal/LoginModal.tsx
+++ b/src/components/modals/LoginModal/LoginModal.tsx
@@ -33,12 +33,18 @@ export default function LoginModal({ open, onClose }: Props) {
   const classes = useStyles();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
 
   const { loginUser } = useLogin();
 
   const loginNow = () => {
-    if (validEntry) {
-      loginUser({ username, password });
+    if (validEntry && !loading) {
+      setLoading(true);
+      loginUser({ username, password }).then((user) => {
+        if (user) {
+          alert("welcome, " + user.attributes.username);
+        }
+      });
     }
   };
 
@@ -78,7 +84,7 @@ export default function LoginModal({ open, onClose }: Props) {
         </FormControl>
         <FormControl>
           <Button
-            disabled={!validEntry}
+            disabled={loading || !validEntry}
             size="large"
             variant="contained"
             color="primary"

--- a/src/config/providers/APIProvider/client.ts
+++ b/src/config/providers/APIProvider/client.ts
@@ -1,8 +1,21 @@
 import { ApolloClient, InMemoryCache } from "@apollo/client";
 import { RestLink } from "apollo-link-rest";
+import { setContext } from "@apollo/client/link/context";
 import { mangadexOffsetLimitPagination } from "./utilities";
+import { getToken } from "../AuthProvider";
 
-const restLink = new RestLink({ uri: "http://localhost:3001" });
+const authLink = setContext((_, { headers }) => {
+  const token = getToken()?.session || "";
+
+  return {
+    headers: {
+      ...headers,
+      authorization: token,
+    },
+  };
+});
+
+const link = authLink.concat(new RestLink({ uri: "http://localhost:3001" }));
 
 const client = new ApolloClient({
   cache: new InMemoryCache({
@@ -14,7 +27,7 @@ const client = new ApolloClient({
       },
     },
   }),
-  link: restLink,
+  link,
 });
 
 export default client;

--- a/src/config/providers/AuthProvider/AuthProvider.tsx
+++ b/src/config/providers/AuthProvider/AuthProvider.tsx
@@ -1,0 +1,81 @@
+import { useApolloClient } from "@apollo/client";
+import React, {
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import { Token, User } from "types/user";
+
+type AuthUser = User | null;
+
+interface AuthContextState {
+  currentUser: AuthUser;
+  setCurrentUser: (user: AuthUser) => void;
+}
+
+export function AuthProvider({ children }: PropsWithChildren<{}>) {
+  const [currentUser, setCurrentUser] = useState<AuthUser>(null);
+  return (
+    <AuthContext.Provider value={{ currentUser, setCurrentUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+const AuthContext = React.createContext<AuthContextState>({
+  currentUser: null,
+  setCurrentUser: (_: AuthUser) => {},
+});
+
+export function useAuth() {
+  const client = useApolloClient();
+  const { currentUser, setCurrentUser } = useContext(AuthContext);
+  const token = useMemo(getToken, [currentUser]);
+
+  const login = useCallback(
+    async (token: Token) => {
+      if (currentUser) {
+        return;
+      }
+
+      // setCurrentUser(user);
+      saveToken(token);
+    },
+    [currentUser]
+  );
+
+  const logout = useCallback(() => {
+    if (!currentUser) {
+      return;
+    }
+
+    setCurrentUser(null);
+    clearToken();
+    client.resetStore();
+  }, [currentUser]);
+
+  return { currentUser, token, login, logout };
+}
+
+function getToken(): Token | null {
+  const savedSession = sessionStorage.getItem("auth.session");
+  const savedRefresh = sessionStorage.getItem("auth.refresh");
+
+  if (savedSession?.length && savedRefresh?.length) {
+    return { session: savedSession, refresh: savedRefresh };
+  }
+
+  return null;
+}
+
+function saveToken(token: Token) {
+  sessionStorage.setItem("auth.session", token.session);
+  sessionStorage.setItem("auth.refresh", token.refresh);
+}
+
+function clearToken() {
+  sessionStorage.removeItem("auth.session");
+  sessionStorage.removeItem("auth.refresh");
+}

--- a/src/config/providers/AuthProvider/AuthProvider.tsx
+++ b/src/config/providers/AuthProvider/AuthProvider.tsx
@@ -89,9 +89,7 @@ export function AuthProvider({ children }: PropsWithChildren<{}>) {
         "X-Auth-Refresh": token?.refresh || "",
       },
     },
-    skip:
-      token == null ||
-      (token.session.length === 0 && token.refresh.length === 0),
+    skip: token == null,
   });
 
   useEffect(() => {

--- a/src/config/providers/AuthProvider/AuthProvider.tsx
+++ b/src/config/providers/AuthProvider/AuthProvider.tsx
@@ -34,14 +34,26 @@ export function useAuth() {
   const { currentUser, setCurrentUser } = useContext(AuthContext);
   const token = useMemo(getToken, [currentUser]);
 
+  // Call this after manually logging in the user
   const login = useCallback(
     async (token: Token) => {
       if (currentUser) {
         return;
       }
 
-      // setCurrentUser(user);
       saveToken(token);
+      const headers = new Headers();
+      headers.append("Authorization", token.session);
+
+      const response = await fetch("http://localhost:3001/user/me", {
+        method: "GET",
+        headers,
+      });
+
+      const user = (await response.json()) as User;
+      setCurrentUser(user);
+
+      return user;
     },
     [currentUser]
   );
@@ -59,7 +71,7 @@ export function useAuth() {
   return { currentUser, token, login, logout };
 }
 
-function getToken(): Token | null {
+export function getToken(): Token | null {
   const savedSession = sessionStorage.getItem("auth.session");
   const savedRefresh = sessionStorage.getItem("auth.refresh");
 

--- a/src/config/providers/AuthProvider/index.ts
+++ b/src/config/providers/AuthProvider/index.ts
@@ -1,0 +1,1 @@
+export * from "./AuthProvider";

--- a/src/config/providers/WithLayoutProvider/CustomAppBar.tsx
+++ b/src/config/providers/WithLayoutProvider/CustomAppBar.tsx
@@ -21,8 +21,10 @@ export function CustomAppBar() {
             aria-haspopup="true"
             color="inherit"
             onClick={() => setOpen(true)}
+            startIcon={<AccountCircle />}
+            size="large"
           >
-            <AccountCircle /> Login
+            Login
           </Button>
         </Grid>
       </Grid>

--- a/src/config/providers/WithLayoutProvider/CustomAppBar.tsx
+++ b/src/config/providers/WithLayoutProvider/CustomAppBar.tsx
@@ -2,31 +2,35 @@ import { Container, Grid, Button } from "@material-ui/core";
 import AccountCircle from "@material-ui/icons/AccountCircle";
 import { LoginModal } from "components/modals";
 import { useState } from "react";
+import { useAuth } from "../AuthProvider";
 import JumpToMangaSearchField from "./JumpToMangaSearchField";
 
 export function CustomAppBar() {
   const [open, setOpen] = useState(false);
+  const { currentUser } = useAuth();
 
   return (
-    <Container>
+    <Container maxWidth={false}>
       <Grid container alignItems="flex-start">
         <Grid item style={{ flex: 1 }}>
           <JumpToMangaSearchField />
         </Grid>
 
-        <Grid item>
-          <Button
-            aria-label="account of current user"
-            aria-controls="primary-search-account-menu"
-            aria-haspopup="true"
-            color="inherit"
-            onClick={() => setOpen(true)}
-            startIcon={<AccountCircle />}
-            size="large"
-          >
-            Login
-          </Button>
-        </Grid>
+        {currentUser ? null : (
+          <Grid item>
+            <Button
+              aria-label="account of current user"
+              aria-controls="primary-search-account-menu"
+              aria-haspopup="true"
+              color="inherit"
+              onClick={() => setOpen(true)}
+              startIcon={<AccountCircle />}
+              size="large"
+            >
+              Login
+            </Button>
+          </Grid>
+        )}
       </Grid>
       <LoginModal open={open} onClose={() => setOpen(false)} />
     </Container>

--- a/src/config/providers/WithLayoutProvider/CustomAppBar.tsx
+++ b/src/config/providers/WithLayoutProvider/CustomAppBar.tsx
@@ -1,4 +1,4 @@
-import { Container, Grid, IconButton } from "@material-ui/core";
+import { Container, Grid, Button } from "@material-ui/core";
 import AccountCircle from "@material-ui/icons/AccountCircle";
 import { LoginModal } from "components/modals";
 import { useState } from "react";
@@ -15,15 +15,15 @@ export function CustomAppBar() {
         </Grid>
 
         <Grid item>
-          <IconButton
+          <Button
             aria-label="account of current user"
             aria-controls="primary-search-account-menu"
             aria-haspopup="true"
             color="inherit"
             onClick={() => setOpen(true)}
           >
-            <AccountCircle />
-          </IconButton>
+            <AccountCircle /> Login
+          </Button>
         </Grid>
       </Grid>
       <LoginModal open={open} onClose={() => setOpen(false)} />

--- a/src/config/providers/WithLayoutProvider/NavigationDrawer/useDrawerItems.tsx
+++ b/src/config/providers/WithLayoutProvider/NavigationDrawer/useDrawerItems.tsx
@@ -6,6 +6,8 @@ import MenuBookIcon from "@material-ui/icons/MenuBook";
 import NewReleasesIcon from "@material-ui/icons/NewReleases";
 import AccountCircleIcon from "@material-ui/icons/AccountCircle";
 import SettingsIcon from "@material-ui/icons/Settings";
+import ExitToAppIcon from "@material-ui/icons/ExitToApp";
+
 import { useHistory } from "react-router";
 import { useAuth } from "config/providers/AuthProvider";
 import { noEmptyArray } from "utils";
@@ -76,7 +78,7 @@ export default function useDrawerItems() {
       },
       {
         content: "Logout",
-        icon: null,
+        icon: <ExitToAppIcon />,
         onClick: logout,
       },
     ]) ||

--- a/src/config/providers/WithLayoutProvider/NavigationDrawer/useDrawerItems.tsx
+++ b/src/config/providers/WithLayoutProvider/NavigationDrawer/useDrawerItems.tsx
@@ -7,6 +7,8 @@ import NewReleasesIcon from "@material-ui/icons/NewReleases";
 import AccountCircleIcon from "@material-ui/icons/AccountCircle";
 import SettingsIcon from "@material-ui/icons/Settings";
 import { useHistory } from "react-router";
+import { useAuth } from "config/providers/AuthProvider";
+import { noEmptyArray } from "utils";
 
 interface BaseDrawerItem {
   icon: ReactNode;
@@ -29,6 +31,7 @@ type DrawerItem = ClickableDrawerItem | LinkableDrawerItem;
 
 export default function useDrawerItems() {
   const history = useHistory();
+  const { currentUser, logout } = useAuth();
 
   const top: Array<DrawerItem> = [
     {
@@ -59,18 +62,25 @@ export default function useDrawerItems() {
       onClick: () => history.push("/"),
     },
   ];
-  const user: Array<DrawerItem> = [
-    {
-      content: "My account",
-      icon: <AccountCircleIcon />,
-      onClick: () => history.push("/"),
-    },
-    {
-      content: "Application settings",
-      icon: <SettingsIcon />,
-      onClick: () => history.push("/"),
-    },
-  ];
+  const user: Array<DrawerItem> =
+    (currentUser && [
+      {
+        content: "My account",
+        icon: <AccountCircleIcon />,
+        onClick: () => history.push("/"),
+      },
+      {
+        content: "Application settings",
+        icon: <SettingsIcon />,
+        onClick: () => history.push("/"),
+      },
+      {
+        content: "Logout",
+        icon: null,
+        onClick: logout,
+      },
+    ]) ||
+    [];
 
-  return [top, manga, user];
+  return [top, manga, user].filter(noEmptyArray);
 }

--- a/src/config/providers/index.ts
+++ b/src/config/providers/index.ts
@@ -1,3 +1,4 @@
 export * from "./APIProvider";
 export * from "./RootProvider";
 export * from "./WithLayoutProvider";
+export * from "./AuthProvider";

--- a/src/helpers/useLogin.ts
+++ b/src/helpers/useLogin.ts
@@ -1,0 +1,44 @@
+import { useMutation } from "@apollo/client";
+import gql from "graphql-tag";
+
+const mutation = gql`
+  mutation LoginUser($username: String!, $password: String!) {
+    loginUser(body: { username: $username, password: $password })
+      @rest(
+        type: "Token"
+        method: "POST"
+        bodyKey: "body"
+        path: "/auth/login"
+      ) {
+      result
+      token
+    }
+  }
+`;
+
+export default function useLogin() {
+  const [login] = useMutation(mutation);
+
+  const loginUser = ({
+    username,
+    password,
+  }: {
+    username: string;
+    password: string;
+  }) => {
+    login({ variables: { username, password } })
+      .then((result) => {
+        if (result.data?.loginUser?.result === "ok") {
+          const token = result.data.loginUser.token;
+
+          sessionStorage.setItem("auth.token", token.session);
+          sessionStorage.setItem("refresh.token", token.refresh);
+        }
+      })
+      .catch((err) => console.log(err));
+  };
+
+  const logoutUser = () => {};
+
+  return { loginUser, logoutUser };
+}

--- a/src/helpers/useLogin.ts
+++ b/src/helpers/useLogin.ts
@@ -1,7 +1,6 @@
 import { useMutation } from "@apollo/client";
 import { useAuth } from "config/providers";
 import gql from "graphql-tag";
-import { useCallback } from "react";
 import { GenericResponse } from "types";
 import { User } from "types/user";
 

--- a/src/helpers/useLogin.ts
+++ b/src/helpers/useLogin.ts
@@ -39,12 +39,6 @@ export default function useLogin(options?: {
     }
 
     return null;
-    // .then((result) => {
-    //   if (result.data?.loginUser?.result === "ok") {
-    //     login(result.data.loginUser.token);
-    //   }
-    // })
-    // .catch((err) => console.log(err));
   };
 
   const logoutUser = () => {};

--- a/src/helpers/useLogin.ts
+++ b/src/helpers/useLogin.ts
@@ -1,6 +1,9 @@
 import { useMutation } from "@apollo/client";
 import { useAuth } from "config/providers";
 import gql from "graphql-tag";
+import { useCallback } from "react";
+import { GenericResponse } from "types";
+import { User } from "types/user";
 
 const loginMutation = gql`
   mutation LoginUser($username: String!, $password: String!) {
@@ -17,16 +20,10 @@ const loginMutation = gql`
   }
 `;
 
-// const authMutation = gql`
-//   mutation AuthUser {
-//     me @rest(type: "User", path: "/user/me") {
-
-//     }
-//   }
-// `;
-
-export default function useLogin() {
-  const { login } = useAuth();
+export default function useLogin(options?: {
+  onLogin: (response: GenericResponse<User>) => void;
+}) {
+  const { login } = useAuth(options);
   const [requestLogin] = useMutation(loginMutation);
 
   const loginUser = async ({
@@ -38,7 +35,7 @@ export default function useLogin() {
   }) => {
     const result = await requestLogin({ variables: { username, password } });
     if (result.data?.loginUser?.result === "ok") {
-      return await login(result.data.loginUser.token);
+      return login(result.data.loginUser.token);
     }
 
     return null;

--- a/src/helpers/useLogin.ts
+++ b/src/helpers/useLogin.ts
@@ -38,8 +38,10 @@ export default function useLogin() {
   }) => {
     const result = await requestLogin({ variables: { username, password } });
     if (result.data?.loginUser?.result === "ok") {
-      const user = await login(result.data.loginUser.token);
+      return await login(result.data.loginUser.token);
     }
+
+    return null;
     // .then((result) => {
     //   if (result.data?.loginUser?.result === "ok") {
     //     login(result.data.loginUser.token);

--- a/src/helpers/useLogin.ts
+++ b/src/helpers/useLogin.ts
@@ -1,7 +1,8 @@
 import { useMutation } from "@apollo/client";
+import { useAuth } from "config/providers";
 import gql from "graphql-tag";
 
-const mutation = gql`
+const loginMutation = gql`
   mutation LoginUser($username: String!, $password: String!) {
     loginUser(body: { username: $username, password: $password })
       @rest(
@@ -16,26 +17,35 @@ const mutation = gql`
   }
 `;
 
-export default function useLogin() {
-  const [login] = useMutation(mutation);
+// const authMutation = gql`
+//   mutation AuthUser {
+//     me @rest(type: "User", path: "/user/me") {
 
-  const loginUser = ({
+//     }
+//   }
+// `;
+
+export default function useLogin() {
+  const { login } = useAuth();
+  const [requestLogin] = useMutation(loginMutation);
+
+  const loginUser = async ({
     username,
     password,
   }: {
     username: string;
     password: string;
   }) => {
-    login({ variables: { username, password } })
-      .then((result) => {
-        if (result.data?.loginUser?.result === "ok") {
-          const token = result.data.loginUser.token;
-
-          sessionStorage.setItem("auth.token", token.session);
-          sessionStorage.setItem("refresh.token", token.refresh);
-        }
-      })
-      .catch((err) => console.log(err));
+    const result = await requestLogin({ variables: { username, password } });
+    if (result.data?.loginUser?.result === "ok") {
+      const user = await login(result.data.loginUser.token);
+    }
+    // .then((result) => {
+    //   if (result.data?.loginUser?.result === "ok") {
+    //     login(result.data.loginUser.token);
+    //   }
+    // })
+    // .catch((err) => console.log(err));
   };
 
   const logoutUser = () => {};

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,15 @@
+export interface User {
+  id: string;
+  type: "user";
+  attributes: UserAttributes;
+}
+
+export interface UserAttributes {
+  username: string;
+  version: number;
+}
+
+export interface Token {
+  session: string;
+  refresh: string;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -159,6 +159,12 @@ export function noEmptyString(value: string | null | undefined) {
   return notEmpty(value) && value.trim().length > 0;
 }
 
+export function noEmptyArray<T>(
+  value: Array<T> | null | undefined
+): value is T[] {
+  return value != null && value.length > 0;
+}
+
 export function openInNewTab(url: string) {
   window.open(url, "_blank");
 }


### PR DESCRIPTION
### Description

This PR is responsible for implementing the log in and out flows for the app. The focus was made on functionality over look and feel.

### Visual changes

- The login button is now a `Button` with an icon.
- The navigation drawer items change depending on whether the user is currently authenticated.

### Proposed architecture

#### Logging in
- Open the login modal (`LoginModal`).
- Enter the `username` and `password`.
- If the `username` and `password` are not valid (ie: too long or too short as per [specifications](https://api.mangadex.org/docs.html#operation/post-auth-login), stop now).
- Initiate the login request through `loginUser({username, password})` (defined in `useLogin`).
- If MangaDex returns a valid response, process the new token using `useAuth`'s `login` function.
- Processing the new token means saving that token, and getting the current user with `GET /auth/check-and-refresh`.
- `login` will resolve with `null` if everything goes without any hiccups. Incidentally, `currentUser` will be set on the `AuthProvider`'s context, available throughout the entire application (via `useAuth`).
- An `onLogin` callback can be passed in to `useAuth` (and `useLogin` as well) to know when the current user is available. This is used by `LoginModal` so it knows when to dismiss itself.

#### Logging out
- One can log out from anywhere in the application, using `useAuth`'s `logout` callback.
- Upon calling this callback, the client's store will be reset, `currentUser` will be set to `null` and clears the session and refresh tokens.

#### On every request
- If the session and refresh tokens are absent, this step will be skipped (ie: no user is currently authenticated).
- If the current user is present from `GET /auth/check-and-refresh`, save the `currentUser` on the context.
- If `session` and `refresh` are available in the response, save those values. Their presence indicate that the refresh token is valid but that the session token had expired. MangaDex allows sessions to be refreshed, similar to how OAuth works.

