### PR TITLE
Use a grid-based CustomGrid component

### DIFF
--- a/src/components/CustomGrid.tsx
+++ b/src/components/CustomGrid.tsx
@@ -1,0 +1,17 @@
+import { makeStyles } from "@material-ui/core";
+import { PropsWithChildren } from "react";
+
+const useStyles = makeStyles(() => ({
+  root: {
+    display: "grid",
+    gap: "28px 30px",
+    gridTemplateColumns: "repeat(auto-fill, 185px)",
+    justifyContent: "space-between",
+  },
+}));
+
+export default function CustomGrid({ children }: PropsWithChildren<{}>) {
+  const classes = useStyles();
+
+  return <div className={classes.root}>{children}</div>;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,3 +4,4 @@ export * from "./MangaCard";
 export * from "./Page";
 export * from "./TitledSection";
 export * from "./ChapterReader";
+export { default as CustomGrid } from "./CustomGrid";

--- a/src/sections/HomePage/HomePage.tsx
+++ b/src/sections/HomePage/HomePage.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@material-ui/core";
-import { Page } from "components";
+import { Page, CustomGrid } from "components";
 import { MangaThumbnail } from "components/Thumbnails";
 import useMangaList from "helpers/useMangaList";
 import { useScrollListeners } from "utils";
@@ -33,16 +33,10 @@ export function HomePage() {
         </Button>
       }
     >
-      <div
-        style={{
-          display: "grid",
-          gap: "28px 30px",
-          gridTemplateColumns: "repeat(auto-fill, 185px)",
-          justifyContent: "space-between",
-        }}
-      >
+      <CustomGrid>
         {mangaList.results.map((mangaResult) => (
           <MangaThumbnail
+            key={mangaResult.data.id}
             chaptersCount={
               mangaResult.relationships.filter(
                 (relationship) => relationship.type === "chapter"
@@ -51,7 +45,7 @@ export function HomePage() {
             manga={mangaResult.data}
           />
         ))}
-      </div>
+      </CustomGrid>
     </Page>
   );
 }

--- a/src/sections/ViewManga/ChaptersList.tsx
+++ b/src/sections/ViewManga/ChaptersList.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@apollo/client";
 import { CircularProgress, Grid } from "@material-ui/core";
-import { Thumbnail, TitledSection } from "components";
+import { CustomGrid, Thumbnail, TitledSection } from "components";
 import { chapterTitle } from "helpers";
 import { useEffect } from "react";
 import { PagedResultsList, Manga } from "types";
@@ -55,7 +55,7 @@ export function ChaptersList({ manga, onFirstChapterReady }: Props) {
   return (
     <>
       <TitledSection title={`Chapters list (${chaptersList.total}) ${bp}`} />
-      <Grid container spacing={2}>
+      <CustomGrid>
         {chaptersList.results.map((chapterInfo, index) => {
           const {
             data: {
@@ -67,17 +67,15 @@ export function ChaptersList({ manga, onFirstChapterReady }: Props) {
             data.length === 1 ? "1 page" : `${data.length} pages`;
 
           return (
-            <Grid item sm={6} md={4} lg={3} xl={2}>
-              <Thumbnail
-                features={[publishedTimeAgo, pagesCount]}
-                title={`${index + 1}) ${chapterTitle(chapterInfo.data)}`}
-                img="https://picsum.photos/185/265"
-                url={`/manga/read/${chapterInfo.data.id}`}
-              />
-            </Grid>
+            <Thumbnail
+              features={[publishedTimeAgo, pagesCount]}
+              title={`${index + 1}) ${chapterTitle(chapterInfo.data)}`}
+              img="https://picsum.photos/185/265"
+              url={`/manga/read/${chapterInfo.data.id}`}
+            />
           );
         })}
-      </Grid>
+      </CustomGrid>
     </>
   );
 }


### PR DESCRIPTION
### Description

Implement a CSS `grid`-based grid-like component, alternative to `Grid` from Material-UI. This new component is used on `HomePage` and `ChaptersList`.

### Usage

```javascript
import {CustomGrid} from 'components';

export function MyComponent({strings}: {strings: Array<string>}) {
  ...
  return (
    <CustomGrid>
      {strings.map((string) => (
        <p key={string}>{string}</p>
      ))}
    </CustomGrid>
  )
} 
```